### PR TITLE
Fix base path so Vercel serves from root while GitHub Pages uses /ak-…

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,9 +4,11 @@ import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@astrojs/react';
 
+const isVercel = !!process.env.VERCEL;
+
 export default defineConfig({
-  site: 'https://kaleoyster.github.io',
-  base: '/ak-blog',
+  site: isVercel ? 'https://ak-blog.vercel.app' : 'https://kaleoyster.github.io',
+  base: isVercel ? '/' : '/ak-blog',
   vite: {
     plugins: [tailwindcss()],
   },


### PR DESCRIPTION
…blog

Vercel sets process.env.VERCEL automatically, use it to switch base/site so asset paths resolve correctly on both deployments.